### PR TITLE
Add starter parkour movement and camera controllers

### DIFF
--- a/Assets/Scripts/Camera/FirstPersonCameraController.cs
+++ b/Assets/Scripts/Camera/FirstPersonCameraController.cs
@@ -1,0 +1,114 @@
+using UnityEngine;
+
+/// <summary>
+/// Simple mouse-look controller for first-person games. Rotates the player root on the yaw axis
+/// while tilting the attached camera on the pitch axis.
+/// </summary>
+public class FirstPersonCameraController : MonoBehaviour
+{
+    [Header("References")]
+    [Tooltip("Transform that represents the player's body. Yaw rotation is applied to this object.")]
+    public Transform playerRoot;
+
+    [Header("Look")]
+    [Tooltip("Mouse sensitivity multiplier.")]
+    public float sensitivity = 2.5f;
+    [Tooltip("Higher values result in slower but smoother camera movement. Set to 0 for instant response.")]
+    public float smoothing = 12f;
+    [Tooltip("Minimum pitch (looking down).")]
+    public float minPitch = -80f;
+    [Tooltip("Maximum pitch (looking up).")]
+    public float maxPitch = 80f;
+    [Tooltip("Lock and hide the cursor while this component is enabled.")]
+    public bool lockCursor = true;
+
+    private float targetYaw;
+    private float targetPitch;
+    private float smoothYaw;
+    private float smoothPitch;
+
+    private void Awake()
+    {
+        Vector3 localEuler = transform.localEulerAngles;
+        targetPitch = smoothPitch = NormalizePitch(localEuler.x);
+        targetYaw = smoothYaw = playerRoot != null ? playerRoot.eulerAngles.y : transform.eulerAngles.y;
+        ApplyCursorState(true);
+    }
+
+    private void OnEnable()
+    {
+        ApplyCursorState(true);
+    }
+
+    private void OnDisable()
+    {
+        ApplyCursorState(false);
+    }
+
+    private void OnApplicationFocus(bool hasFocus)
+    {
+        if (hasFocus)
+        {
+            ApplyCursorState(true);
+        }
+        else
+        {
+            ApplyCursorState(false);
+        }
+    }
+
+    private void Update()
+    {
+        float mouseX = Input.GetAxisRaw("Mouse X");
+        float mouseY = Input.GetAxisRaw("Mouse Y");
+
+        targetYaw += mouseX * sensitivity;
+        targetPitch -= mouseY * sensitivity;
+        targetPitch = Mathf.Clamp(targetPitch, minPitch, maxPitch);
+
+        float lerpFactor = smoothing > 0f ? 1f - Mathf.Exp(-smoothing * Time.deltaTime) : 1f;
+        smoothYaw = Mathf.LerpAngle(smoothYaw, targetYaw, lerpFactor);
+        smoothPitch = Mathf.Lerp(smoothPitch, targetPitch, lerpFactor);
+
+        if (playerRoot != null)
+        {
+            playerRoot.rotation = Quaternion.Euler(0f, smoothYaw, 0f);
+            transform.localRotation = Quaternion.Euler(smoothPitch, 0f, 0f);
+        }
+        else
+        {
+            transform.rotation = Quaternion.Euler(smoothPitch, smoothYaw, 0f);
+        }
+    }
+
+    private float NormalizePitch(float eulerX)
+    {
+        eulerX %= 360f;
+        if (eulerX > 180f)
+        {
+            eulerX -= 360f;
+        }
+        return eulerX;
+    }
+
+    private void ApplyCursorState(bool shouldLock)
+    {
+        if (!lockCursor)
+        {
+            Cursor.lockState = CursorLockMode.None;
+            Cursor.visible = true;
+            return;
+        }
+
+        if (shouldLock)
+        {
+            Cursor.lockState = CursorLockMode.Locked;
+            Cursor.visible = false;
+        }
+        else
+        {
+            Cursor.lockState = CursorLockMode.None;
+            Cursor.visible = true;
+        }
+    }
+}

--- a/Assets/Scripts/Movement/ParkourMovementController.cs
+++ b/Assets/Scripts/Movement/ParkourMovementController.cs
@@ -1,0 +1,447 @@
+using UnityEngine;
+
+/// <summary>
+/// CharacterController-based locomotion script tuned for fast-paced parkour gameplay.
+/// Supports sprinting, crouching, double jumps, wall running, and wall jumps out of the box.
+/// </summary>
+[RequireComponent(typeof(CharacterController))]
+public class ParkourMovementController : MonoBehaviour
+{
+    [Header("Movement")]
+    [Tooltip("Base walking speed while on the ground.")]
+    public float walkSpeed = 5f;
+    [Tooltip("Speed while holding the sprint key and moving forward.")]
+    public float sprintSpeed = 8.5f;
+    [Tooltip("Speed while crouched.")]
+    public float crouchSpeed = 3f;
+    [Tooltip("How quickly horizontal velocity responds to input.")]
+    public float acceleration = 12f;
+    [Range(0f, 1f)]
+    [Tooltip("Multiplier applied to acceleration while airborne.")]
+    public float airControl = 0.35f;
+
+    [Header("Jumping")]
+    [Tooltip("Height reached by the initial ground jump.")]
+    public float jumpHeight = 1.6f;
+    [Tooltip("Height reached by each additional air jump.")]
+    public float doubleJumpHeight = 1.3f;
+    [Tooltip("Number of air jumps available after leaving the ground.")]
+    public int extraAirJumps = 1;
+
+    [Header("Gravity")]
+    [Tooltip("Gravity applied while airborne. A negative value pushes the player downward.")]
+    public float gravity = -24f;
+    [Tooltip("Small downward force applied while grounded to keep the controller snapped to the floor.")]
+    public float groundedGravity = -4f;
+
+    [Header("Crouch")]
+    [Tooltip("Target height for the CharacterController while crouched.")]
+    public float crouchHeight = 1.1f;
+    [Tooltip("Speed used when interpolating between standing and crouching heights.")]
+    public float crouchTransitionSpeed = 12f;
+
+    [Header("Wall Running")]
+    [Tooltip("Maximum distance to detect climbable walls to the left/right.")]
+    public float wallCheckDistance = 0.75f;
+    [Tooltip("Layers that are considered valid for wall running.")]
+    public LayerMask wallMask = ~0;
+    [Tooltip("Horizontal speed target while sliding along a wall.")]
+    public float wallRunSpeed = 9f;
+    [Tooltip("Gravity applied while wall running. Closer to zero means longer runs.")]
+    public float wallRunGravity = -2.5f;
+    [Tooltip("Upward velocity imparted when jumping off a wall.")]
+    public float wallJumpUpVelocity = 9f;
+    [Tooltip("Lateral velocity applied away from the contacted wall during a wall jump.")]
+    public float wallJumpPushVelocity = 9f;
+    [Tooltip("Minimum height above the ground before a wall run can begin.")]
+    public float minWallRunHeight = 1.5f;
+
+    [Header("Ground Detection")]
+    [Tooltip("Optional transform for sphere-based ground checks. If omitted, CharacterController.isGrounded is used.")]
+    public Transform groundCheck;
+    [Tooltip("Radius for the optional ground check sphere.")]
+    public float groundCheckRadius = 0.25f;
+    [Tooltip("Layers considered ground when using the optional ground check.")]
+    public LayerMask groundMask = ~0;
+
+    [Header("Input")]
+    public KeyCode sprintKey = KeyCode.LeftShift;
+    public KeyCode crouchKey = KeyCode.LeftControl;
+    [Tooltip("Name of the horizontal axis inside Unity's Input Manager.")]
+    public string horizontalAxis = "Horizontal";
+    [Tooltip("Name of the vertical axis inside Unity's Input Manager.")]
+    public string verticalAxis = "Vertical";
+    [Tooltip("Name of the jump button inside Unity's Input Manager.")]
+    public string jumpButton = "Jump";
+
+    private CharacterController controller;
+    private CharacterController Controller
+    {
+        get
+        {
+            if (controller == null)
+            {
+                controller = GetComponent<CharacterController>();
+            }
+
+            return controller;
+        }
+    }
+
+    private Vector3 planarVelocity;
+    private float verticalVelocity;
+    private bool isGrounded;
+    private bool isSprinting;
+    private bool isCrouching;
+    private bool isWallRunning;
+    private Vector3 currentWallNormal;
+    private Vector3 wallDirection;
+    private int remainingAirJumps;
+
+    private float defaultHeight;
+    private Vector3 defaultCenter;
+
+    /// <summary> Current world-space velocity of the character. </summary>
+    public Vector3 CurrentVelocity => planarVelocity + Vector3.up * verticalVelocity;
+    public bool IsGrounded => isGrounded;
+    public bool IsWallRunning => isWallRunning;
+    public bool IsCrouching => isCrouching;
+    public bool IsSprinting => isSprinting;
+
+    private void Awake()
+    {
+        CharacterController cc = Controller;
+        defaultHeight = cc.height;
+        defaultCenter = cc.center;
+        crouchHeight = Mathf.Clamp(crouchHeight, 0.5f, defaultHeight);
+        remainingAirJumps = extraAirJumps;
+    }
+
+    private void Update()
+    {
+        ReadInput(out Vector2 moveInput, out bool jumpPressed, out bool sprintHeld, out bool crouchHeld);
+
+        UpdateGroundedState();
+        UpdateSprintState(sprintHeld, moveInput);
+        UpdateCrouchState(crouchHeld);
+        HandleWallRun(moveInput);
+        HandleJump(jumpPressed);
+        ApplyMovement(moveInput);
+        ApplyGravity();
+        ApplyCharacterControllerMove();
+    }
+
+    private void ReadInput(out Vector2 moveInput, out bool jumpPressed, out bool sprintHeld, out bool crouchHeld)
+    {
+        float horizontal = Input.GetAxisRaw(horizontalAxis);
+        float vertical = Input.GetAxisRaw(verticalAxis);
+        moveInput = new Vector2(horizontal, vertical);
+        moveInput = Vector2.ClampMagnitude(moveInput, 1f);
+
+        jumpPressed = Input.GetButtonDown(jumpButton);
+        sprintHeld = Input.GetKey(sprintKey);
+        crouchHeld = Input.GetKey(crouchKey);
+    }
+
+    private void UpdateGroundedState()
+    {
+        CharacterController cc = Controller;
+        bool previousGrounded = isGrounded;
+        if (groundCheck != null)
+        {
+            int mask = groundMask == 0 ? Physics.DefaultRaycastLayers : groundMask;
+            isGrounded = Physics.CheckSphere(groundCheck.position, groundCheckRadius, mask, QueryTriggerInteraction.Ignore);
+        }
+        else
+        {
+            isGrounded = cc.isGrounded;
+        }
+
+        if (isGrounded)
+        {
+            remainingAirJumps = extraAirJumps;
+            if (verticalVelocity < 0f)
+            {
+                verticalVelocity = groundedGravity;
+            }
+            isWallRunning = false;
+        }
+        else if (previousGrounded)
+        {
+            // Leaving the ground resets vertical velocity so jumps feel responsive.
+            if (verticalVelocity < 0f)
+            {
+                verticalVelocity = 0f;
+            }
+        }
+    }
+
+    private void UpdateSprintState(bool sprintHeld, Vector2 moveInput)
+    {
+        isSprinting = sprintHeld && moveInput.y > 0.1f && !isCrouching && !isWallRunning;
+    }
+
+    private void UpdateCrouchState(bool crouchHeld)
+    {
+        CharacterController cc = Controller;
+
+        if (crouchHeld)
+        {
+            isCrouching = true;
+        }
+        else if (isCrouching)
+        {
+            if (HasHeadClearance())
+            {
+                isCrouching = false;
+            }
+        }
+
+        float targetHeight = isCrouching ? crouchHeight : defaultHeight;
+        Vector3 targetCenter = isCrouching
+            ? new Vector3(defaultCenter.x, crouchHeight / 2f, defaultCenter.z)
+            : defaultCenter;
+
+        cc.height = Mathf.Lerp(cc.height, targetHeight, crouchTransitionSpeed * Time.deltaTime);
+        cc.center = Vector3.Lerp(cc.center, targetCenter, crouchTransitionSpeed * Time.deltaTime);
+    }
+
+    private bool HasHeadClearance()
+    {
+        CharacterController cc = Controller;
+        float radius = cc.radius - 0.05f;
+        if (radius <= 0f)
+        {
+            radius = cc.radius * 0.95f;
+        }
+
+        float castDistance = defaultHeight - cc.height;
+        if (castDistance <= 0f)
+        {
+            return true;
+        }
+
+        Vector3 origin = transform.position + cc.center + Vector3.up * (cc.height / 2f - radius);
+        return !Physics.SphereCast(origin, radius, Vector3.up, out _, castDistance + 0.05f, Physics.DefaultRaycastLayers, QueryTriggerInteraction.Ignore);
+    }
+
+    private void HandleWallRun(Vector2 moveInput)
+    {
+        if (isGrounded || IsNearGround(minWallRunHeight))
+        {
+            EndWallRun();
+            return;
+        }
+
+        if (moveInput.y <= 0.1f)
+        {
+            EndWallRun();
+            return;
+        }
+
+        if (TryGetWall(out RaycastHit hit))
+        {
+            if (!isWallRunning)
+            {
+                remainingAirJumps = extraAirJumps; // Refresh air jumps once when entering a wall run.
+            }
+
+            isWallRunning = true;
+            currentWallNormal = hit.normal;
+            wallDirection = Vector3.Cross(currentWallNormal, Vector3.up).normalized;
+            if (Vector3.Dot(wallDirection, transform.forward) < 0f)
+            {
+                wallDirection = -wallDirection;
+            }
+        }
+        else
+        {
+            EndWallRun();
+        }
+    }
+
+    private bool TryGetWall(out RaycastHit hit)
+    {
+        CharacterController cc = Controller;
+        Vector3 origin = transform.position + cc.center + Vector3.up * (cc.height * 0.5f);
+        bool leftHit = Physics.Raycast(origin, -transform.right, out RaycastHit leftInfo, wallCheckDistance, wallMask, QueryTriggerInteraction.Ignore);
+        bool rightHit = Physics.Raycast(origin, transform.right, out RaycastHit rightInfo, wallCheckDistance, wallMask, QueryTriggerInteraction.Ignore);
+
+        if (leftHit && Vector3.Dot(leftInfo.normal, Vector3.up) < 0.3f)
+        {
+            hit = leftInfo;
+            return true;
+        }
+
+        if (rightHit && Vector3.Dot(rightInfo.normal, Vector3.up) < 0.3f)
+        {
+            hit = rightInfo;
+            return true;
+        }
+
+        hit = default;
+        return false;
+    }
+
+    private void EndWallRun()
+    {
+        isWallRunning = false;
+        wallDirection = Vector3.zero;
+    }
+
+    private void HandleJump(bool jumpPressed)
+    {
+        if (!jumpPressed)
+        {
+            return;
+        }
+
+        if (isGrounded)
+        {
+            verticalVelocity = Mathf.Sqrt(Mathf.Max(jumpHeight, 0.01f) * -2f * gravity);
+            return;
+        }
+
+        if (isWallRunning)
+        {
+            EndWallRun();
+            Vector3 push = Vector3.ProjectOnPlane(currentWallNormal * wallJumpPushVelocity, Vector3.up);
+            Vector3 planar = Vector3.ProjectOnPlane(planarVelocity, Vector3.up);
+            planarVelocity = planar + push;
+            verticalVelocity = wallJumpUpVelocity;
+            remainingAirJumps = extraAirJumps;
+            return;
+        }
+
+        if (remainingAirJumps > 0)
+        {
+            verticalVelocity = Mathf.Sqrt(Mathf.Max(doubleJumpHeight, 0.01f) * -2f * gravity);
+            remainingAirJumps--;
+        }
+    }
+
+    private void ApplyMovement(Vector2 moveInput)
+    {
+        Vector3 desiredDirection = transform.forward * moveInput.y + transform.right * moveInput.x;
+        desiredDirection = Vector3.ClampMagnitude(desiredDirection, 1f);
+
+        float targetSpeed = GetTargetSpeed();
+        Vector3 desiredVelocity = desiredDirection * targetSpeed;
+
+        float lerpRate = acceleration * (isGrounded || isWallRunning ? 1f : airControl);
+        float lerpFactor = Mathf.Clamp01(lerpRate * Time.deltaTime);
+        planarVelocity = Vector3.Lerp(planarVelocity, desiredVelocity, lerpFactor);
+
+        if (isWallRunning)
+        {
+            Vector3 wallVelocity = wallDirection * wallRunSpeed;
+            planarVelocity = Vector3.Lerp(planarVelocity, wallVelocity, Mathf.Clamp01(acceleration * Time.deltaTime));
+        }
+
+        planarVelocity.y = 0f;
+    }
+
+    private float GetTargetSpeed()
+    {
+        if (isWallRunning)
+        {
+            return wallRunSpeed;
+        }
+
+        if (isCrouching)
+        {
+            return crouchSpeed;
+        }
+
+        if (isSprinting)
+        {
+            return sprintSpeed;
+        }
+
+        return walkSpeed;
+    }
+
+    private void ApplyGravity()
+    {
+        if (isWallRunning)
+        {
+            verticalVelocity += wallRunGravity * Time.deltaTime;
+            verticalVelocity = Mathf.Max(verticalVelocity, wallRunGravity);
+        }
+        else
+        {
+            verticalVelocity += gravity * Time.deltaTime;
+        }
+    }
+
+    private void ApplyCharacterControllerMove()
+    {
+        Vector3 velocity = planarVelocity;
+        velocity.y = verticalVelocity;
+        Controller.Move(velocity * Time.deltaTime);
+    }
+
+    private void OnDrawGizmosSelected()
+    {
+        Gizmos.color = Color.green;
+        if (groundCheck != null)
+        {
+            Gizmos.DrawWireSphere(groundCheck.position, groundCheckRadius);
+        }
+
+        Color wallColor = isWallRunning ? Color.cyan : Color.yellow;
+        Gizmos.color = wallColor;
+
+        CharacterController cc = Controller;
+        float height = cc != null ? cc.height * 0.5f : 1f;
+        Vector3 origin = transform.position + (cc != null ? cc.center : Vector3.up * 0.5f);
+        origin += Vector3.up * height * 0.5f;
+        Gizmos.DrawLine(origin, origin + transform.right * wallCheckDistance);
+        Gizmos.DrawLine(origin, origin - transform.right * wallCheckDistance);
+    }
+
+    private bool IsNearGround(float distance)
+    {
+        if (distance <= 0f)
+        {
+            return false;
+        }
+
+        int mask = groundMask == 0 ? Physics.DefaultRaycastLayers : groundMask;
+        Vector3 origin = transform.position + Controller.center;
+        origin.y += 0.1f;
+        return Physics.Raycast(origin, Vector3.down, distance, mask, QueryTriggerInteraction.Ignore);
+    }
+
+    private void OnValidate()
+    {
+        walkSpeed = Mathf.Max(0f, walkSpeed);
+        sprintSpeed = Mathf.Max(0f, sprintSpeed);
+        crouchSpeed = Mathf.Max(0f, crouchSpeed);
+        acceleration = Mathf.Max(0f, acceleration);
+        airControl = Mathf.Clamp01(airControl);
+        jumpHeight = Mathf.Max(0f, jumpHeight);
+        doubleJumpHeight = Mathf.Max(0f, doubleJumpHeight);
+        extraAirJumps = Mathf.Max(0, extraAirJumps);
+        if (gravity > -0.01f)
+        {
+            gravity = -0.01f;
+        }
+        if (groundedGravity > -0.01f)
+        {
+            groundedGravity = -0.01f;
+        }
+        crouchHeight = Mathf.Max(0.1f, crouchHeight);
+        crouchTransitionSpeed = Mathf.Max(0f, crouchTransitionSpeed);
+        wallCheckDistance = Mathf.Max(0.05f, wallCheckDistance);
+        wallRunSpeed = Mathf.Max(0f, wallRunSpeed);
+        if (wallRunGravity > -0.01f)
+        {
+            wallRunGravity = -0.01f;
+        }
+        wallJumpUpVelocity = Mathf.Max(0f, wallJumpUpVelocity);
+        wallJumpPushVelocity = Mathf.Max(0f, wallJumpPushVelocity);
+        minWallRunHeight = Mathf.Max(0f, minWallRunHeight);
+        groundCheckRadius = Mathf.Max(0.01f, groundCheckRadius);
+    }
+}

--- a/Docs/MovementSystem.md
+++ b/Docs/MovementSystem.md
@@ -1,0 +1,72 @@
+# Movement System Overview
+
+This document breaks down how `ParkourMovementController` works and how you can extend it for your own prototypes. The script is written for Unity's `CharacterController` component because it gives deterministic movement, keeps collision handling straightforward, and works well for first-person and third-person games alike.
+
+## Core responsibilities
+
+`ParkourMovementController` is responsible for:
+
+1. Reading input from Unity's legacy input system (`Input.GetAxis` and `Input.GetButton`).
+2. Tracking high-level locomotion states such as **grounded**, **airborne**, **crouched**, and **wall running**.
+3. Producing a final velocity vector by blending horizontal motion, vertical motion, and state-specific adjustments.
+4. Applying the velocity to the `CharacterController` each frame.
+
+The controller intentionally avoids any animation or camera coupling, so you can keep those systems modular.
+
+## State machine
+
+At runtime the character flows through the following states:
+
+- **Grounded** – default movement with configurable walk, sprint, and crouch speeds.
+- **Airborne** – standard jumping/falling with optional double jumps.
+- **Wall Running** – triggered when the character is airborne, moving forward, and a valid wall is detected to the left or right.
+- **Crouched** – modifies the character height and movement speed.
+
+The controller does not use a formal `enum` for the state machine; instead, booleans such as `isGrounded`, `isWallRunning`, and `isCrouching` determine how the velocity is composed. This approach keeps the script flexible so you can blend new behaviors without rewriting the structure.
+
+### Wall running detection
+
+Wall runs are detected with two raycasts (left and right). When one hits a collider that matches the `Wall Mask`, the controller:
+
+- Stores the wall normal for later use in jumping and directional calculations.
+- Accelerates the player along the cross product of the wall normal and the global up vector.
+- Reduces gravity while wall running to allow longer traversal without an artificial boost.
+
+Jumping while wall running launches the player away from the wall using configurable push and upward forces. When the wall is lost (raycast misses, the player moves too slowly, or falls below the minimum height) the script gracefully exits the wall-run state.
+
+### Crouch logic
+
+Pressing the crouch key immediately shortens the `CharacterController` and adjusts its center. Attempting to stand up first checks for headroom using a capsule cast so the player does not clip through ceilings. You can tune the crouch height in the inspector to match your character's proportions.
+
+## Inspector parameters
+
+The most important tunables are:
+
+| Group | Parameter | Description |
+|-------|-----------|-------------|
+| Movement | Walk/Sprint/Crouch Speed | Base speeds for different locomotion modes. |
+| Movement | Acceleration & Air Control | Lerp factors that determine how fast the player reaches target velocities. |
+| Jumping | Jump Height | Controls the upward velocity applied when jumping from the ground. |
+| Jumping | Extra Air Jumps & Double Jump Height | Allow mid-air jumps when wall running is not active. |
+| Gravity | Gravity & Grounded Gravity | Control falling speed and the sticky force that keeps the controller grounded. |
+| Wall Running | Check Distance, Speed, Gravity, Jump Forces | Determine how forgiving and fast wall runs feel. |
+| Ground Detection | Ground Check Transform/Radius/Mask | Optional override for manual ground detection using a sphere check. |
+
+`FirstPersonCameraController` exposes sensitivity, pitch limits, and smoothing parameters for camera motion. It expects to be attached to the Camera object with a reference to the player root transform so yaw rotates the body while pitch tilts only the camera.
+
+## Extending the controller
+
+Here are a few common extensions and where to start:
+
+- **Mantling / Ledge Grab** – Hook into the section that resolves jumps (`HandleJump`). Detect when the player is near a ledge and replace the jump impulse with a coroutine that animates the character upward onto the ledge.
+- **Slide or Dash** – Introduce a new state flag and adjust horizontal speeds in `ApplyMovement`. You can reuse the crouch height logic to lower the character collider temporarily.
+- **Stamina System** – Track a stamina value, drain it while sprinting or wall running, and gate the states when stamina is depleted. The script exposes helper properties like `IsSprinting` to drive UI feedback.
+- **Animation** – Use the `CurrentVelocity` and state properties in an animator controller to blend walk/run cycles, air animations, and wall-run poses.
+
+## Debugging tips
+
+- Toggle Gizmos in the Scene view to see the ground-check sphere and wall-check rays drawn by `OnDrawGizmosSelected`.
+- Enable the `Use Inspector` checkboxes for `Ground Mask` and `Wall Mask` to ensure your level geometry is included.
+- Watch the `Inspector` during play mode; the serialized fields such as `IsWallRunning` expose the current state, which makes diagnosing edge cases easier.
+
+By starting with this framework you can focus on crafting interesting level layouts, traversal challenges, and game-specific rules rather than rebuilding core locomotion for every prototype.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,49 @@
+# Parkour Framework
+
+A Unity-focused sandbox for rapidly prototyping parkour movement mechanics. The goal is to provide a clean starting point that already understands running, crouching, wall running, and double jumping so you can immediately focus on level design, visuals, and advanced tricks.
+
+## Repository layout
+
+```
+Assets/
+  Scripts/
+    Camera/
+      FirstPersonCameraController.cs   # Basic mouse-look controller for FPS-style games
+    Movement/
+      ParkourMovementController.cs     # CharacterController-based locomotion with parkour states
+Docs/
+  MovementSystem.md                    # Deep dive into the movement state machine and extension ideas
+```
+
+## Getting started in Unity
+
+1. Create a new 3D Unity project (2021.3 LTS or newer is recommended for the built-in CharacterController).
+2. Copy the contents of this repository into your project directory (or pull it in as a submodule).
+3. Create a **Player** GameObject and add the following components:
+   - `CharacterController`
+   - `ParkourMovementController`
+4. Configure the inspector values on `ParkourMovementController`. Start with the defaults and tweak speeds, jump heights, and wall-run parameters for your prototype.
+5. Create a child GameObject that holds the `Camera` and add `FirstPersonCameraController` to it. Drag the parent player transform into the script's `playerRoot` field.
+6. Ensure your project uses Unity's legacy input manager (Edit → Project Settings → Input Manager) with the default axes `Horizontal`, `Vertical`, `Mouse X`, `Mouse Y`, and `Jump`. The scripts read from these mappings and expose configurable key bindings for sprinting and crouching.
+
+### Quick play checklist
+
+- Place the player on a simple level built with colliders.
+- Set `Ground Mask` to include the layers that represent the floor.
+- Provide `Wall Mask` so the controller knows which surfaces can be used for wall runs.
+- Tune `Min Wall Run Height` to prevent wall runs when the player is already touching the ground.
+- Use the Gizmos visualization (select the player in the Scene view) to see the ground and wall checks during play mode.
+
+## Feature highlights
+
+- **Ground locomotion** with acceleration, sprinting, and crouching.
+- **Vertical gameplay** through jump, double jump, and wall-jump actions.
+- **Wall running** that aligns the player's motion along detected surfaces and modulates gravity while active.
+- **Context-aware input handling** so sprinting and crouching play nicely with other states.
+- **Camera look controller** with smoothing and clamped pitch for a comfortable first-person experience.
+
+## Extending the framework
+
+The documentation in [`Docs/MovementSystem.md`](Docs/MovementSystem.md) outlines how the movement script is structured and points to areas where you can add mantling, ledge grabbing, sliding, stamina systems, or animation integration. The script is intentionally heavily commented to ease customization.
+
+If you add systems like climbing, combat, or networking, consider organizing them under new folders inside `Assets/Scripts/` to keep the project tidy.


### PR DESCRIPTION
## Summary
- add a CharacterController-based parkour locomotion script covering sprinting, crouching, double jumps, wall runs, and wall jumps
- add a first-person camera controller for smooth mouse look and cursor locking
- document the project layout and movement system details to help integrate the scripts into a Unity project

## Testing
- not run (Unity scripts only)


------
https://chatgpt.com/codex/tasks/task_b_68d0eb7ae4488333bd59e3160e8c67b5